### PR TITLE
Fix versions and travis for robot tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,13 +21,22 @@ before_install:
 install:
   - sed -ie "s#release/5.0-latest#release/$PLONE_MINOR_VERSION#" buildout.cfg
   - sed -ie "s#travis-5.0.x#travis-$PLONE_MAJOR_VERSION#" travis.cfg
-  - python bootstrap-buildout.py -c travis.cfg
+# Keep setuptools and zc.buildout versions in sync with buildout.cfg.
+  - python bootstrap-buildout.py --setuptools-version=28.7.1 --buildout-version=2.5.3 -c travis.cfg
 # Try this twice, as first time could fail with strange setuptools error.
   - bin/buildout -c travis.cfg || true
   - bin/buildout -c travis.cfg
+# before_script:
+#   - export DISPLAY=:99.0
+#   - sh -e /etc/init.d/xvfb start
+#   - firefox -v
 script:
   - bin/code-analysis
   - bin/test
+# Use --all when robot tests work on Plone 5.  It works in practice, but not in the tests.
+# Switching to the new resource registries would probably help.
+# We would need to do that for jquery.pyproxy as well then.
+#   - bin/test --all
 after_success:
   - bin/createcoverage
   - pip install coveralls

--- a/bootstrap-buildout.py
+++ b/bootstrap-buildout.py
@@ -25,7 +25,10 @@ import tempfile
 
 from optparse import OptionParser
 
-tmpeggs = tempfile.mkdtemp()
+__version__ = '2015-07-01'
+# See zc.buildout's changelog if this version is up to date.
+
+tmpeggs = tempfile.mkdtemp(prefix='bootstrap-')
 
 usage = '''\
 [DESIRED PYTHON FOR BUILDOUT] bootstrap.py [options]
@@ -40,8 +43,9 @@ this script from going over the network.
 '''
 
 parser = OptionParser(usage=usage)
-parser.add_option("-v", "--version", help="use a specific zc.buildout version")
-
+parser.add_option("--version",
+                  action="store_true", default=False,
+                  help=("Return bootstrap.py version."))
 parser.add_option("-t", "--accept-buildout-test-releases",
                   dest='accept_buildout_test_releases',
                   action="store_true", default=False,
@@ -59,25 +63,33 @@ parser.add_option("-f", "--find-links",
 parser.add_option("--allow-site-packages",
                   action="store_true", default=False,
                   help=("Let bootstrap.py use existing site packages"))
+parser.add_option("--buildout-version",
+                  help="Use a specific zc.buildout version")
 parser.add_option("--setuptools-version",
-                  help="use a specific setuptools version")
-
+                  help="Use a specific setuptools version")
+parser.add_option("--setuptools-to-dir",
+                  help=("Allow for re-use of existing directory of "
+                        "setuptools versions"))
 
 options, args = parser.parse_args()
+if options.version:
+    print("bootstrap.py version %s" % __version__)
+    sys.exit(0)
+
 
 ######################################################################
 # load/install setuptools
 
 try:
-    if options.allow_site_packages:
-        import setuptools
-        import pkg_resources
     from urllib.request import urlopen
 except ImportError:
     from urllib2 import urlopen
 
 ez = {}
-exec(urlopen('https://bootstrap.pypa.io/ez_setup.py').read(), ez)
+if os.path.exists('ez_setup.py'):
+    exec(open('ez_setup.py').read(), ez)
+else:
+    exec(urlopen('https://bootstrap.pypa.io/ez_setup.py').read(), ez)
 
 if not options.allow_site_packages:
     # ez_setup imports site, which adds site packages
@@ -88,12 +100,19 @@ if not options.allow_site_packages:
     # We can't remove these reliably
     if hasattr(site, 'getsitepackages'):
         for sitepackage_path in site.getsitepackages():
-            sys.path[:] = [x for x in sys.path if sitepackage_path not in x]
+            # Strip all site-packages directories from sys.path that
+            # are not sys.prefix; this is because on Windows
+            # sys.prefix is a site-package directory.
+            if sitepackage_path != sys.prefix:
+                sys.path[:] = [x for x in sys.path
+                               if sitepackage_path not in x]
 
 setup_args = dict(to_dir=tmpeggs, download_delay=0)
 
 if options.setuptools_version is not None:
     setup_args['version'] = options.setuptools_version
+if options.setuptools_to_dir is not None:
+    setup_args['to_dir'] = options.setuptools_to_dir
 
 ez['use_setuptools'](**setup_args)
 import setuptools
@@ -110,7 +129,12 @@ for path in sys.path:
 
 ws = pkg_resources.working_set
 
+setuptools_path = ws.find(
+    pkg_resources.Requirement.parse('setuptools')).location
+
+# Fix sys.path here as easy_install.pth added before PYTHONPATH
 cmd = [sys.executable, '-c',
+       'import sys; sys.path[0:0] = [%r]; ' % setuptools_path +
        'from setuptools.command.easy_install import main; main()',
        '-mZqNxd', tmpeggs]
 
@@ -123,11 +147,8 @@ find_links = os.environ.get(
 if find_links:
     cmd.extend(['-f', find_links])
 
-setuptools_path = ws.find(
-    pkg_resources.Requirement.parse('setuptools')).location
-
 requirement = 'zc.buildout'
-version = options.version
+version = options.buildout_version
 if version is None and not options.accept_buildout_test_releases:
     # Figure out the most recent final version of zc.buildout.
     import setuptools.package_index
@@ -167,7 +188,7 @@ if version:
 cmd.append(requirement)
 
 import subprocess
-if subprocess.call(cmd, env=dict(os.environ, PYTHONPATH=setuptools_path)) != 0:
+if subprocess.call(cmd) != 0:
     raise Exception(
         "Failed to execute command:\n%s" % repr(cmd)[1:-1])
 

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -53,15 +53,24 @@ eggs =
 [versions]
 # Don't use a relased version of zest.emailhider
 zest.emailhider =
-
+# Keep setuptools and zc.buildout versions in sync with .travis.yml.
+setuptools = 28.7.1
+zc.buildout = 2.5.3
+# Other packages:
+argh = 0.26.2
+check-manifest = 0.34
+configparser = 3.5.0
 coverage = 3.7.1
+enum34 = 1.1.6
 flake8 = 3.0.4
+flake8-blind-except = 0.1.1
+flake8-coding = 1.3.0
+flake8-debugger = 1.4.0
 jquery.pyproxy = 0.5
-robotframework = 2.8.4
-robotframework-ride = 1.3
-robotframework-selenium2library = 1.6.0
-robotsuite = 1.6.1
-selenium = 2.46.0
-setuptools = 18.3.2
-zc.buildout = 2.4.4
-zc.recipe.egg = 2.0.3
+mccabe = 0.5.2
+pathtools = 0.1.2
+plone.recipe.codeanalysis = 2.2
+pycodestyle = 2.0.0
+pyflakes = 1.2.3
+PyYAML = 3.12
+watchdog = 0.8.3


### PR DESCRIPTION
We can't test with 'bin/test --all' yet because it fails on Plone 5.
Switching to the new resource registries would probably help.
We would need to do that for jquery.pyproxy as well then.