### PR TITLE
Query and reveal all emails at once.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,11 @@ History of zest.emailhider package
 3.1 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Query and reveal all emails at once.  If you have an employee
+  content type that you have hooked up to zest.emailhider, and you
+  have a page showing fifty employees, previously we would fire fifty
+  ajax requests.  Now we gather everything into one request.
+  [maurits]
 
 
 3.0 (2015-10-03)

--- a/zest/emailhider/browser/emailhider.js
+++ b/zest/emailhider/browser/emailhider.js
@@ -1,9 +1,16 @@
 $(document).ready(function() {
-    var reveal_url = 'jq_reveal_email'
-    if (typeof(portal_url) != 'undefined') {
-	reveal_url = portal_url + '/' + reveal_url;
-    }
-    $('a.hidden-email').each(function() {
-        $.pyproxy_call(reveal_url, {'uid': $(this).attr('rel')});
-    });
+  'use strict';
+  var reveal_url;
+  var uids;
+  reveal_url = 'jq_reveal_email';
+  if (typeof(portal_url) !== 'undefined') {
+	  reveal_url = portal_url + '/' + reveal_url;
+  }
+  uids = [];
+  $('a.hidden-email').each(function() {
+    uids.push($(this).attr('rel'));
+  });
+  if (uids) {
+    $.pyproxy_call(reveal_url, {'uid': uids});
+  }
 });


### PR DESCRIPTION
If you have an employee content type that you have hooked up to
zest.emailhider, and you have a page showing fifty employees,
previously we would fire fifty ajax requests.  Now we gather
everything into one request.